### PR TITLE
docs: fix dlt branding, CLI title grammar, and a non-existent CLI command

### DIFF
--- a/src/main/java/io/kestra/plugin/dlt/CLI.java
+++ b/src/main/java/io/kestra/plugin/dlt/CLI.java
@@ -26,7 +26,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Execute dlt (data load tool) commands to extract, and load data from various sources",
+    title = "Execute dlt (data load tool) commands to extract and load data from various sources",
     description = "dlt is an open-source Python library that loads data from various data sources into well-structured datasets. " +
         "It offers a lightweight interface for extracting data from REST APIs, SQL databases, cloud storage, Python data structures, and many more."
 )

--- a/src/main/java/io/kestra/plugin/dlt/package-info.java
+++ b/src/main/java/io/kestra/plugin/dlt/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Dlt (Data Load Tool)",
+    title = "dlt (Data Load Tool)",
     description = "This sub-group of plugins contains tasks to interact with dlt (data load tool).\n" +
         "dlt is an open-source library for declaratively loading data from APIs, databases, and files into data warehouses and lakes.",
     categories = { PluginSubGroup.PluginCategory.DATA }

--- a/src/main/resources/doc/io.kestra.plugin.dlt.md
+++ b/src/main/resources/doc/io.kestra.plugin.dlt.md
@@ -8,6 +8,6 @@ dlt pipelines authenticate to sources and destinations via environment variables
 
 ## Tasks
 
-`CLI` runs dlt CLI commands in a container (default image `ghcr.io/kestra-io/dlt`) — set `commands` (required, list of shell commands such as `dlt init`, `dlt pipeline`, or `dlt run`). Use `beforeCommands` for setup steps, `env` for credentials, `inputFiles` to stage local files, and `outputFiles` to retrieve results.
+`CLI` runs dlt CLI commands in a container (default image `ghcr.io/kestra-io/dlt`) — set `commands` (required, list of shell commands such as `dlt init`, `dlt pipeline`, or `dlt deploy`). Use `beforeCommands` for setup steps, `env` for credentials, `inputFiles` to stage local files, and `outputFiles` to retrieve results.
 
 `Run` executes an inline Python dlt script — set `script` (required, a Python string that defines and runs the pipeline). Use `beforeCommands`, `env`, `inputFiles`, and `outputFiles` the same way as `CLI`. The default container image is also `ghcr.io/kestra-io/dlt`.


### PR DESCRIPTION
## Summary

Documentation correctness + completeness review of **plugin-dlt** (task-level `@Schema`/`@Example` annotations, `package-info.java`, `metadata/index.yaml`, and the how-to doc). Docs-only pass — no behavior, defaults, `@NotNull`, or `group` changes. 2 tasks: `CLI` (runs dlt CLI commands) and `Run` (runs an inline Python dlt script); both extend `AbstractExecScript`.

### Doc fixes in this PR

- **`dlt` branding.** The `@PluginSubGroup` title was "Dlt (Data Load Tool)". The canonical product styling is lowercase `dlt` (as in `index.yaml`, the how-to, and every description). Lowercased to "dlt (Data Load Tool)".
- **Non-existent CLI command in the how-to.** The `CLI` task description listed example commands "`dlt init`, `dlt pipeline`, or `dlt run`". `dlt run` is **not** a dlt CLI command (dlt's CLI has `init`/`pipeline`/`deploy`/`schema`/`telemetry`; pipelines are executed with `python <script>.py`). Replaced with `dlt deploy`, matching the task's own `@Schema` description.
- **Grammar.** Removed a stray comma in the `CLI` task title ("extract, and load" → "extract and load").

Everything else was accurate and left unchanged: all five examples (CSV→DuckDB, Zendesk, REST API/Pokémon, Chess trace, dlt init), `script`/`commands` (`@NotNull`), the default image `ghcr.io/kestra-io/dlt`, the `--non-interactive` + post-`init` `requirements.txt` auto-injection described in `index.yaml`, and the how-to authentication section (dlt's `SOURCES__…__CREDENTIALS__…` env convention). Verified the `io.kestra.plugin.core.flow.WorkingDirectory` FQCN in the Chess example against the registry (canonical — `WorkingDir` does not exist).

## Notes

- No `@Metric` declared on either task (both delegate to `ScriptOutput`); nothing to verify there.
- `AGENTS.md` is stale/templated boilerplate — not a doc surface, noting for cleanup.
